### PR TITLE
Onboarding: add import smoke test + initial profiling notes

### DIFF
--- a/docs/profiling_notes.md
+++ b/docs/profiling_notes.md
@@ -1,0 +1,8 @@
+# Profiling notes (initial)
+
+- Target example: `examples/symbolic_regression.test_tgp_sr` (or closest available)
+- Env: Ubuntu on WSL2, Python: `python --version`
+
+Next:
+- Run: `python -m cProfile -o prof.out -m examples.symbolic_regression.test_tgp_sr`
+- Inspect: `python -c "import pstats; p=pstats.Stats('prof.out'); p.sort_stats('cumtime').print_stats(20)"`

--- a/tests/test_imports_gp.py
+++ b/tests/test_imports_gp.py
@@ -1,0 +1,5 @@
+import importlib
+
+def test_import_gp_package():
+    mod = importlib.import_module("gp")
+    assert hasattr(mod, "__package__")


### PR DESCRIPTION
This PR includes:
- A minimal smoke test to ensure the `gp` package imports correctly.
- `docs/profiling_notes.md` with initial notes for profiling the symbolic regression example.

Context:
As discussed during our call, I will begin with a small onboarding contribution before proceeding with the fitness-metrics study (MSE vs. correlation/similarity).
Let me know if anything should be adjusted.  

Thanks!
